### PR TITLE
Updates on Clip informal spec and hypothesis tests

### DIFF
--- a/safety-related-profile/sonnx/ops/spec/informal/clip/clip.md
+++ b/safety-related-profile/sonnx/ops/spec/informal/clip/clip.md
@@ -42,6 +42,7 @@ The result is stored in output tensor $Y$.
 Clip operation can be expressed as:
 
 $$\forall i,\ Y[i] = \min(M, \max(X[i], L))$$
+
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
 
 
@@ -171,6 +172,7 @@ The result is stored in output tensor $Y$.
 Clip operation can be expressed as:
 
 $$\forall i,\ Y[i] = \min(M, \max(X[i], L))$$
+
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
 
 ### Example 1
@@ -312,6 +314,7 @@ Clip operation can be divided into two steps:
 - The clipping is then performed as:
 
 $$\forall i,\ Y[i] = \min(M, \max(X[i], L))$$
+
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
 
 

--- a/safety-related-profile/sonnx/ops/spec/informal/clip/clip.md
+++ b/safety-related-profile/sonnx/ops/spec/informal/clip/clip.md
@@ -1,45 +1,43 @@
 # Contents
 
-- **clip** operator for type [real](#real)
-- **clip** operator for types [INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64](#int)
-- **clip** operator for types [FP16, FP32, FP64, BFLOAT16](#floats)
+- **Clip** operator for type [real](#real)
+- **Clip** operator for types [INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64](#int)
+- **Clip** operator for types [FP16, FP32, FP64, BFLOAT16](#floats)
 
 Based on ONNX documentation version 13.
 
 <a id="real"></a>
-# **clip** (real)
+# **Clip** (real)
 
 ## Signature
-$Y = \text{clip}(X,L,M)$
+$Y = \text{Clip}(X,L,M)$
 
 where:
-- `X`: input tensor
-- `L`: minimum tensor (empty shape tensor - scalar)
-- `M`: maximum tensor (empty shape tensor - scalar)
+- $X$: input tensor
+- $L$: minimum tensor (empty shape tensor - scalar)
+- $M$: maximum tensor (empty shape tensor - scalar)
 
 ## Restrictions
-The following restrictions apply to the **clip** operator for the SONNX profile:
+The following restrictions apply to the $\text{Clip}$ operator for the SONNX profile:
 
-| Restriction | Statement                                                   | Origin                                                                                      |
-|-------------|-------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `[R1]`     | Input L must be set                           | [No default values](../../../deliverables/reqs/reqs.md#no_default_value) |
-| `[R2]`     | Input M must be set                           | [No default values](../../../deliverables/reqs/reqs.md#no_default_value) |
-| `[R3]`     | Sparse tensors are not supported              | General restriction [GR1](../general_restrictions.md#GR1) |
-| `[R4]`     <a id="R1"></a>     | Shape of tensors shall be explicit          | General restriction [GR2](../general_restrictions.md#GR2) |
+[General restrictions](../general_restrictions.md) are applicable.
+
 
 ## Informal specification
 
-Operator **clip** limit the given input within an interval. For each element in the input tensor `X`: 
-- If `L` $\leq$ `M`:
-  - if $X[i]$ < `L` then $Y[i]$ = `L`.
-  - If $X[i]$ > `M` then $Y[i]$ = `M`.
+Operator $\text{Clip}$ limit the given input within an interval. For each element in the input tensor $X$: 
+- If $L$ $\leq$ $M$:
+
+  - if $X[i]$ < $L$ then $Y[i]$ = $L$.
+
+  - If $X[i]$ > $M$ then $Y[i]$ = $M$.
   - Otherwise, $Y[i]$ = $X[i]$.
-- If `L` $\gt$ `M`:
+- If $L$ $\gt$ $M$:
   - $\forall i,\ Y[i] = M$
 
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
 
-The result is stored in output tensor `Y`.
+The result is stored in output tensor $Y$.
 
 Clip operation can be expressed as:
 
@@ -57,6 +55,10 @@ A = \begin{bmatrix} -6.1 & 9.5 & 35.7 \end{bmatrix}
 L = 0
 \quad
 M = 10
+```
+
+```math
+Y = \begin{bmatrix} \min(10, \max(-6.1, 0)) & \min(10, \max(9.5, 0)) & \min(10, \max(35.7, 0)) \end{bmatrix}
 ```
 
 ```math
@@ -88,44 +90,44 @@ No error condition
 
 ## Inputs
 
-### $X$: real
-Tensor `X` is the input tensor to be clipped within the specified bounds.
+### $\text{X}$: `real tensor`
+Tensor $X$ is the input tensor to be clipped within the specified bounds.
 
 ### Constraints
 
  - `[C1]` <a id="C1ra"></a> Shape consistency
-   - Statement: Tensors `X` and `Y` must have the same shape.
+   - Statement: Tensors $X$ and $Y$ must have the same shape.
  
-### $L$: real
-Tensor `L` is the minimum bound for clipping.
+### $\text{L}$: `real tensor`
+Tensor $L$ is the minimum bound for clipping.
 
-The shape of tensor `L` must be empty (scalar).
-
-### Constraints
-Tensor `L` has no constraints.
-
-### $M$: real
-Tensor `M` is the maximum bound for clipping.
-
-The shape of tensor `M` must be empty (scalar).
+The shape of tensor $L$ must be empty (scalar).
 
 ### Constraints
-Tensor `M` has no constraints.
+Tensor $L$ has no constraints.
+
+### $\text{M}$: `real tensor`
+Tensor $M$ is the maximum bound for clipping.
+
+The shape of tensor $M$ must be empty (scalar).
+
+### Constraints
+Tensor $M$ has no constraints.
 
 ## Outputs
 
-### $Y$: real
-Tensor `Y` is the element-wise result of clipping `X` by the interval $[L, M]$.
+### $\text{Y}$: `real tensor`
+Tensor $Y$ is the element-wise result of clipping $X$ by the interval $[L, M]$.
 
 ### Constraints
 
  - `[C1]` Shape consistency
-   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C1]</span></b>](#C1ra) on tensor `X`.
+   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C1]</span></b>](#C1ra) on tensor $X$.
 
 
 ## Attributes
 
-Operator **clip** has no attribute.
+Operator $\text{Clip}$ has no attribute.
 
 ## Formal specification
  
@@ -133,43 +135,38 @@ See the Why3 specification.
 
 ## Numerical Accuracy
 
-Operator **clip** does not introduce any numerical error. Hence, for all valid indexes $i$,
+Operator $\text{Clip}$ does not introduce any numerical error. Hence, for all valid indexes, the output values are exactly equal to the corresponding input values.
 
 <a id="int"></a>
 # **clip** (int, int, int)
 where int is in {INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64}
 
 ## Signature
-$Y = \text{clip}(X,L,M)$
+$Y = \text{Clip}(X,L,M)$
 
 where:
-- `X`: input tensor
-- `L`: minimum tensor (empty shape tensor - scalar)
-- `M`: maximum tensor (empty shape tensor - scalar)
-
+- $X$: input tensor
+- $L$: minimum tensor (empty shape tensor - scalar)
+- $M$: maximum tensor (empty shape tensor - scalar)
 ## Restrictions
-The following restrictions apply to the **clip** operator for the SONNX profile:
+The following restrictions apply to the $\text{Clip}$ operator for the SONNX profile:
 
-| Restriction | Statement                                                   | Origin                                                                                      |
-|-------------|-------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `[R1]`     | Input L must be set                           | [No default values](../../../deliverables/reqs/reqs.md#no_default_value) |
-| `[R2]`     | Input M must be set                           | [No default values](../../../deliverables/reqs/reqs.md#no_default_value) |
-| `[R3]`     | Sparse tensors are not supported              | General restriction [GR1](../general_restrictions.md#GR1) |
-| `[R4]`     <a id="R1"></a>     | Shape of tensors shall be explicit          | General restriction [GR2](../general_restrictions.md#GR2) |
-| `[R5]` <a id="R5"></a>     | All tensors shall have the same datatype  | General restriction [GR3](../general_restrictions.md#GR3) |
+[General restrictions](../general_restrictions.md) are applicable.
 ## Informal specification
 
-Operator **clip** limit the given input within an interval. For each element in the input tensor `X`: 
-- If `L` $\leq$ `M`:
-  - if $X[i]$ < `L` then $Y[i]$ = `L`.
-  - If $X[i]$ > `M` then $Y[i]$ = `M`.
+Operator $\text{Clip}$ limit the given input within an interval. For each element in the input tensor $X$: 
+- If $L$ $\leq$ $M$:
+
+  - if $X[i]$ < $L$ then $Y[i]$ = $L$.
+
+  - If $X[i]$ > $M$ then $Y[i]$ = $M$.
   - Otherwise, $Y[i]$ = $X[i]$.
-- If `L` $\gt$ `M`:
+- If $L$ $\gt$ $M$:
   - $\forall i,\ Y[i] = M$
 
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
 
-The result is stored in output tensor `Y`.
+The result is stored in output tensor $Y$.
 
 Clip operation can be expressed as:
 
@@ -186,6 +183,10 @@ A = \begin{bmatrix} -6 & 9 & 35 \end{bmatrix}
 L = 0
 \quad
 M = 10
+```
+
+```math
+Y = \begin{bmatrix} \min(10, \max(-6, 0)) & \min(10, \max(9, 0)) & \min(10, \max(35, 0)) \end{bmatrix}
 ```
 
 ```math
@@ -217,49 +218,48 @@ No error condition
 
 ## Inputs
 
-### $X$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
-Tensor `X` is the input tensor to be clipped within the specified bounds.
+### $\text{X}$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
+Tensor $X$ is the input tensor to be clipped within the specified bounds.
 
 ### Constraints
 
  - `[C1]` <a id="C1ia"></a> Shape consistency
-   - Statement: Tensors `X` and `Y` must have the same shape.
+   - Statement: Tensors $X$ and $Y$ must have the same shape.
  - `[C2]` <a id="C2ia"></a> Type consistency
-   - Statement: Tensors `X`, `L`, `M` and `Y` must have the same type.
+   - Statement: Tensors $X$, $L$, $M$ and $Y$ must have the same type.
  
-### $L$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
-Tensor `L` is the minimum bound for clipping.
+### $\text{L}$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
+Tensor $L$ is the minimum bound for clipping.
 
-The shape of tensor `L` must be empty (scalar).
-
-### Constraints
-- `[C1]` Type consistency
-  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor `X`.
-
-### $M$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
-Tensor `M` is the maximum bound for clipping.
-
-The shape of tensor `M` must be empty (scalar).
+The shape of tensor $L$ must be empty (scalar).
 
 ### Constraints
 - `[C1]` Type consistency
-  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor `X`.
+  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor $X$.
+
+### $\text{M}$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
+Tensor $M$ is the maximum bound for clipping.
+
+The shape of tensor $M$ must be empty (scalar).
+### Constraints
+- `[C1]` Type consistency
+  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor $X$.
 
 ## Outputs
 
-### $Y$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
-Tensor `Y` is the element-wise result of clipping `X` by the interval $[L, M]$.
+### $\text{Y}$: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
+Tensor $Y$ is the element-wise result of clipping $X$ by the interval $[L, M]$.
 
 ### Constraints
 
  - `[C1]` Shape consistency
-   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C1]</span></b>](#C1ra) on tensor `X`.
+   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C1]</span></b>](#C1ra) on tensor $X$.
  - `[C2]` Type consistency
-   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">  [C2]</span></b>](#C2ia) on tensor `X`.
+   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">  [C2]</span></b>](#C2ia) on tensor $X$.
 
 ## Attributes
 
-Operator **clip** has no attribute.
+Operator $\text{Clip}$ has no attribute.
 
 ## Formal specification
  
@@ -267,56 +267,53 @@ See the Why3 specification.
 
 ## Numerical Accuracy
 
-Operator **clip** does not introduce any numerical error. Hence, for all valid indexes $i$,
+Operator $\text{Clip}$ does not introduce any numerical error. Hence, for all valid indexes, the output values are exactly equal to the corresponding input values.
 
 
 <a id="float"></a>
-# **clip** (float, float, float)
+# **Clip** (float, float, float)
 where float is in {FP16, FP32, FP64, BFLOAT16}
 
 ## Signature
-$Y = \text{clip}(X,L,M)$
-
+$Y = \text{Clip}(X,L,M)$
 where:
-- `X`: input tensor
-- `L`: minimum tensor (empty shape tensor - scalar)
-- `M`: maximum tensor (empty shape tensor - scalar)
+- $X$: input tensor
+- $L$: minimum tensor (empty shape tensor - scalar)
+- $M$: maximum tensor (empty shape tensor - scalar)
 
 ## Restrictions
-The following restrictions apply to the **clip** operator for the SONNX profile:
+The following restrictions apply to the $\text{Clip}$ operator for the SONNX profile:
 
-| Restriction | Statement                                                   | Origin                                                                                      |
-|-------------|-------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `[R1]`     | Input L must be set                           | [No default values](../../../deliverables/reqs/reqs.md#no_default_value) |
-| `[R2]`     | Input M must be set                           | [No default values](../../../deliverables/reqs/reqs.md#no_default_value) |
-| `[R3]`     | Sparse tensors are not supported              | General restriction [GR1](../general_restrictions.md#GR1) |
-| `[R4]`     <a id="R1"></a>     | Shape of tensors shall be explicit          | General restriction [GR2](../general_restrictions.md#GR2) |
-| `[R5]` <a id="R5"></a>     | All tensors shall have the same datatype  | General restriction [GR3](../general_restrictions.md#GR3) |
+[General restrictions](../general_restrictions.md) are applicable.
+
 ## Informal specification
 
-Operator **clip** limit the given input within an interval. For each element in the input tensor `X` (discarding `nan` values in `L` or `M`, for more details see the definition below):
-- If `L` $\leq$ `M`:
-  - if $X[i]$ < `L` then $Y[i]$ = `L`.
-  - If $X[i]$ > `M` then $Y[i]$ = `M`.
+Operator $\text{Clip}$ limit the given input within an interval. For each element in the input tensor $X$ (discarding $nan$ values in $L$ or $M$, for more details see the definition below):
+- If $L$ $\leq$ $M$:
+
+  - if $X[i]$ < $L$ then $Y[i]$ = $L$.
+
+  - If $X[i]$ > $M$ then $Y[i]$ = $M$.
   - Otherwise, $Y[i]$ = $X[i]$.
-- If `L` $\gt$ `M`:
+- If $L$ $\gt$ $M$:
   - $\forall i,\ Y[i] = M$
 
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
 
-The result is stored in output tensor `Y`.
+The result is stored in output tensor $Y$.
 
-Clip operation can be expressed as:
+Clip operation can be divided into two steps:
 
-$$\forall i,\ Y[i] = 
-\begin{cases} 
-\min(X[i], M) & \text{ if } L = \text{nan} \\
-\max(X[i], L) & \text{ if } M = \text{nan} \\
-X[i] & \text{ if } L = \text{nan} \text{ and } M = \text{nan} \\
-\min(M, \max(X[i], L)) & \text{ otherwise }  \\
-\end{cases}$$
+- If any of the boundaries is $nan$ it is readjusted to the respetive extreme value:
 
+  - If $L$ is $nan$, it is set to the lowest representable value.
+
+  - If $M$ is $nan$, it is set to the highest representable value.
+- The clipping is then performed as:
+
+$$\forall i,\ Y[i] = \min(M, \max(X[i], L))$$
 where $i$ is a [tensor index](../common/definitions.md#tensor_index).
+
 
 
 ### Example 1
@@ -329,6 +326,9 @@ A = \begin{bmatrix} -6.3 & 9.2 & 35.5 \end{bmatrix}
 L = 0.5
 \quad
 M = 10.1
+```
+```math
+Y = \begin{bmatrix} \min(10.1, \max(-6.3, 0.5)) & \min(10.1, \max(9.2, 0.5)) & \min(10.1, \max(35.5, 0.5)) \end{bmatrix}
 ```
 
 ```math
@@ -365,9 +365,13 @@ L = -1.0
 \quad
 M = NaN
 ```
+```math
+M = h 
+```
+where `h` is the highest representable value.
 
 ```math
-Y = \begin{bmatrix} \max(-\infty, -1.0) & \max(0.0, -1.0) & \max(\infty, -1.0) & \max(NaN, -1.0) \end{bmatrix}
+Y = \begin{bmatrix} \min(h, \max(-\infty, -1.0)) & \min(h, \max(0.0, -1.0)) & \min(h, \max(\infty, -1.0)) & \min(h, \max(NaN, -1.0)) \end{bmatrix}
 ```
 
 ```math
@@ -384,6 +388,16 @@ L = NaN
 \quad
 M = NaN
 ```
+```math
+L = l \quad M = h
+```
+where: 
+  - `l` is the lowest representable value and 
+  - `h` is the highest representable value.
+
+```math
+Y = \begin{bmatrix} \min(h, \max(-\infty, l)) & \min(h, \max(0.0, l)) & \min(h, \max(\infty, l)) & \min(h, \max(NaN, l)) \end{bmatrix}
+```
 
 ```math
 Y = \begin{bmatrix} -\infty & 0.0 & \infty & NaN \end{bmatrix}
@@ -394,54 +408,51 @@ Y = \begin{bmatrix} -\infty & 0.0 & \infty & NaN \end{bmatrix}
 
 ## Inputs
 
-### $X$: FP16, FP32, FP64, BFLOAT16
-Tensor `X` is the input tensor to be clipped within the specified bounds.
+### $\text{X}$: FP16, FP32, FP64, BFLOAT16
+Tensor $X$ is the input tensor to be clipped within the specified bounds.
 
 ### Constraints
 
  - `[C1]` <a id="C1ia"></a> Shape consistency
-   - Statement: Tensors `X` and `Y` must have the same shape.
+   - Statement: Tensors $X$ and $Y$ must have the same shape.
  - `[C2]` <a id="C2ia"></a> Type consistency
-   - Statement: Tensors `X`, `L`, `M` and `Y` must have the same type.
+   - Statement: Tensors $X$, $L$, $M$ and $Y$ must have the same type.
  
-### $L$: FP16, FP32, FP64, BFLOAT16
-Tensor `L` is the minimum bound for clipping.
+### $\text{L}$: FP16, FP32, FP64, BFLOAT16
+Tensor $L$ is the minimum bound for clipping.
 
-The shape of tensor `L` must be empty (scalar).
-
-### Constraints
-- `[C1]` Type consistency
-  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor `X`.
-
-### $M$: FP16, FP32, FP64, BFLOAT16
-Tensor `M` is the maximum bound for clipping.
-
-The shape of tensor `M` must be empty (scalar).
+The shape of tensor $L$ must be empty (scalar).
 
 ### Constraints
 - `[C1]` Type consistency
-  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor `X`.
+  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor $X$.
 
+### $\text{M}$: FP16, FP32, FP64, BFLOAT16
+Tensor $M$ is the maximum bound for clipping.
+
+The shape of tensor $M$ must be empty (scalar).
+
+### Constraints
+- `[C1]` Type consistency
+  - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C2]</span></b>](#C2ia) on tensor $X$.
 ## Outputs
 
-### $Y$: FP16, FP32, FP64, BFLOAT16
-Tensor `Y` is the element-wise result of clipping `X` by the interval $[L, M]$.
-
+### $\text{Y}$: FP16, FP32, FP64, BFLOAT16
+Tensor $Y$ is the element-wise result of clipping $X$ by the interval $[L, M]$.
 ### Constraints
 
  - `[C1]` Shape consistency
-   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C1]</span></b>](#C1ra) on tensor `X`.
+   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">[C1]</span></b>](#C1ra) on tensor $X$.
  - `[C2]` Type consistency
-   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">  [C2]</span></b>](#C2ia) on tensor `X`.
+   - Statement: see constraint [<b><span style="font-family: 'Courier New', monospace">  [C2]</span></b>](#C2ia) on tensor $X$.
 
 ## Attributes
 
-Operator **clip** has no attribute.
+Operator $\text{Clip}$ has no attribute.
 
 ## Formal specification
  
 See the Why3 specification.
 
 ## Numerical Accuracy
-
-Operator **clip** does not introduce any numerical error. Hence, for all valid indexes $i$,
+Operator $\text{Clip}$ does not introduce any numerical error. Hence, for all valid indexes, the output values are exactly equal to the corresponding input values.


### PR DESCRIPTION
Two step computations for float datatypes, on informal spec.
Adapting formula and notations styles.
Parameterized hypothesis tests in terms of providers and available datatypes.


cc:[@JGalego](https://github.com/JGalego)